### PR TITLE
Fix Vercel excludeFiles schema limit

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -4,7 +4,7 @@
   "functions": {
     "app.py": {
       "maxDuration": 60,
-      "excludeFiles": "{backup/**,data_processing/**,database_management/**,deployment/**,docs/**,plot_generation/**,scripts/**,synthetic_data_examples/**,testing/**,tests/**,utils/diagnostic_plots/**,utils/generate_*.py,utils/*diagnostic*.py,public/**,Dockerfile,docker-compose.yml,render.yaml,render_build.py,Makefile,pytest.ini,requirements-dev.txt}"
+      "excludeFiles": "{public/**,utils/diagnostic_plots/**,utils/generate_*.py,utils/*diagnostic*.py}"
     }
   },
   "headers": [


### PR DESCRIPTION
## What changed

Shortens `functions.app.py.excludeFiles` in `vercel.json` from 329 characters to 79 characters.

## Why

Vercel rejects `excludeFiles` values longer than 256 characters during schema validation. Directories and root files removed from this field remain excluded by `.vercelignore`; `public/**` and runtime-adjacent diagnostic utilities remain excluded from the Python function bundle.

## Validation

- Parsed `vercel.json` as JSON
- Confirmed `excludeFiles` is 79/256 characters
- Confirmed the removed exclusions remain present in `.vercelignore`
- Ran `git diff --check`