### PR TITLE
Fix encoded statistical model group links

### DIFF
--- a/routes/main_routes.py
+++ b/routes/main_routes.py
@@ -5,6 +5,7 @@ from datetime import datetime
 import json
 import random
 from collections import OrderedDict
+from urllib.parse import unquote
 main = Blueprint('main', __name__)
 # -----------------------------------------------------------------------------
 # MODEL GROUPING FOR NAVIGATION DROPDOWN
@@ -664,6 +665,9 @@ def history():
 def models_in_group(group_name):
     """Display models belonging to a specific group."""
     model_database = current_app.config.get('MODEL_DATABASE', {})
+    # Some clients and previously rendered links can encode the path segment
+    # twice, leaving a literal ``%20`` after Flask's first URL decode.
+    group_name = unquote(group_name)
     # Validate group_name
     if group_name not in MODEL_GROUPS:
         flash(f"Invalid model group: {group_name}", "danger")

--- a/tests/test_main_routes.py
+++ b/tests/test_main_routes.py
@@ -14,6 +14,12 @@ class TestMainRoutes:
         response = client.get('/analysis-form')
         assert response.status_code == 200
         assert b'form' in response.data.lower() or b'analysis' in response.data.lower()
+    def test_double_encoded_model_group_url(self, client):
+        """Previously generated encoded group links remain usable."""
+        response = client.get('/models/Regression%2520Models')
+        assert response.status_code == 200
+        assert b'Invalid model group' not in response.data
+        assert b'Linear Regression' in response.data
     def test_analysis_form_submission_authenticated(self, authenticated_client, sample_analysis_data, app):
         """Test analysis form submission with authenticated user."""
         response = authenticated_client.post('/results', data=sample_analysis_data, follow_redirects=True)


### PR DESCRIPTION
## What changed

- Decode a model-group route parameter once more before validating it.
- Preserve compatibility with double-encoded links such as `Regression%2520Models`.
- Add regression coverage confirming the Regression Models page renders normally.

## Root cause

The browser or an intermediate link encoded `%20` a second time. Flask decoded the outer layer, leaving the literal value `Regression%20Models`, which did not match the `Regression Models` group key.

## Validation

- 21 main-route tests passed
- 117 supported tests passed
- Strict flake8 error checks passed
- `git diff --check` passed
