### PR TITLE
Fix AI review and comparison runtime

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -10,7 +10,7 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.0/font/bootstrap-icons.css">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/app.css') }}">
-    <link rel="stylesheet" href="{{ url_for('static', filename='css/chatbot.css') }}">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/chatbot.css', v='20260725.1') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/page_search.css') }}">
     {% block extra_css %}{% endblock %}
 </head>
@@ -184,7 +184,7 @@
     </button>
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
-    <script src="{{ url_for('static', filename='js/chatbot.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/chatbot.js', v='20260725.1') }}"></script>
     <script>
     document.addEventListener('DOMContentLoaded', function () {
         document.querySelectorAll('[data-bs-toggle="tooltip"]').forEach(function (element) {

--- a/templates/blank.html
+++ b/templates/blank.html
@@ -15,7 +15,7 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.0/font/bootstrap-icons.css">
     
     <!-- Chatbot CSS -->
-    <link rel="stylesheet" href="{{ url_for('static', filename='css/chatbot.css') }}">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/chatbot.css', v='20260725.1') }}">
     
     <!-- Page Search CSS -->
     <link rel="stylesheet" href="{{ url_for('static', filename='css/page_search.css') }}">
@@ -92,11 +92,11 @@
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
     
     <!-- Chatbot JS -->
-    <script src="{{ url_for('static', filename='js/chatbot.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/chatbot.js', v='20260725.1') }}"></script>
     
     <!-- Page Search JS -->
     <script src="{{ url_for('static', filename='js/page_search.js') }}"></script>
     
     {% block scripts %}{% endblock %}
 </body>
-</html> 
+</html>

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -76,6 +76,47 @@ def test_openai_supports_strict_structured_outputs(monkeypatch):
     }
 
 
+def test_openai_allows_a_larger_feature_specific_output_budget(monkeypatch):
+    monkeypatch.setenv("AI_ENHANCEMENT_ENABLED", "true")
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    monkeypatch.setenv("AI_MAX_OUTPUT_TOKENS", "400")
+    response = Mock(output_text='{"answer":"complete"}', status="completed")
+    client = Mock()
+    client.responses.create.return_value = response
+
+    with patch("utils.ai_service.OpenAI", return_value=client):
+        result = call_openai_api(
+            "Return the complete review.",
+            max_output_tokens=1_500,
+        )
+
+    assert result == '{"answer":"complete"}'
+    assert (
+        client.responses.create.call_args.kwargs["max_output_tokens"]
+        == 1_500
+    )
+
+
+def test_openai_rejects_an_incomplete_provider_response(monkeypatch):
+    monkeypatch.setenv("AI_ENHANCEMENT_ENABLED", "true")
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    response = Mock(
+        output_text='{"answer":"cut off',
+        status="incomplete",
+    )
+    client = Mock()
+    client.responses.create.return_value = response
+
+    with patch("utils.ai_service.OpenAI", return_value=client):
+        with pytest.raises(
+            OpenAIServiceError,
+            match="exceeded its output limit",
+        ) as error:
+            call_openai_api("Return the complete review.")
+
+    assert error.value.status_code == 502
+
+
 def test_recommendation_ai_is_limited_to_verified_candidates():
     model_database = {
         "Linear Regression": {
@@ -128,6 +169,7 @@ def test_recommendation_ai_is_limited_to_verified_candidates():
         }
     ]
     schema = generate.call_args.kwargs["response_schema"]
+    assert generate.call_args.kwargs["max_output_tokens"] == 1_500
     assert schema["properties"]["recommended_model"]["enum"] == [
         "Linear Regression",
         "Random Forest",

--- a/tests/test_main_routes.py
+++ b/tests/test_main_routes.py
@@ -11,6 +11,8 @@ class TestMainRoutes:
         response = client.get('/')
         assert response.status_code == 200
         assert b'statistical' in response.data.lower() or b'model' in response.data.lower()
+        assert b'chatbot.js?v=20260725.1' in response.data
+        assert b'chatbot.css?v=20260725.1' in response.data
     def test_analysis_form_page(self, client):
         """Test that the analysis form page loads."""
         response = client.get('/analysis-form')

--- a/utils/ai_service.py
+++ b/utils/ai_service.py
@@ -55,11 +55,15 @@ def _timeout_seconds() -> float:
         return 45.0
 
 
-def _max_output_tokens() -> int:
-    raw_limit = os.environ.get("AI_MAX_OUTPUT_TOKENS", "400")
+def _max_output_tokens(override: Optional[int] = None) -> int:
+    raw_limit = (
+        override
+        if override is not None
+        else os.environ.get("AI_MAX_OUTPUT_TOKENS", "400")
+    )
     try:
         return min(max(int(raw_limit), 100), 1_500)
-    except ValueError:
+    except (TypeError, ValueError):
         return 400
 
 
@@ -75,6 +79,7 @@ def call_openai_api(
     safety_identifier: Optional[str] = None,
     response_schema: Optional[dict[str, Any]] = None,
     schema_name: str = "structured_response",
+    max_output_tokens: Optional[int] = None,
 ) -> str:
     """Generate text through OpenAI's Responses API."""
     if not is_ai_enabled():
@@ -100,7 +105,7 @@ def call_openai_api(
         "model": target_model,
         "instructions": system_prompt or DEFAULT_SYSTEM_PROMPT,
         "input": cleaned_prompt,
-        "max_output_tokens": _max_output_tokens(),
+        "max_output_tokens": _max_output_tokens(max_output_tokens),
         "reasoning": {"effort": _reasoning_effort()},
         "store": False,
     }
@@ -169,6 +174,11 @@ def call_openai_api(
 
     if response is None:
         raise OpenAIServiceError("The AI provider returned no response.", 502)
+    if getattr(response, "status", None) == "incomplete":
+        raise OpenAIServiceError(
+            "The AI provider response exceeded its output limit.",
+            502,
+        )
     content = response.output_text
     if not isinstance(content, str) or not content.strip():
         raise OpenAIServiceError("The AI provider returned an empty response.", 502)

--- a/utils/recommendation_ai.py
+++ b/utils/recommendation_ai.py
@@ -138,6 +138,7 @@ def review_recommendation(
         safety_identifier=safety_identifier,
         response_schema=_review_schema(verified_candidates),
         schema_name="model_recommendation_review",
+        max_output_tokens=1_500,
     )
 
     try:


### PR DESCRIPTION
## Root cause

Production Vercel logs showed that OpenAI successfully returned `200 OK` for recommendation reviews, but the structured JSON was truncated by the shared `AI_MAX_OUTPUT_TOKENS=400` setting. Every review then failed JSON parsing and fell back to the rules-based result.

The comparison chatbot endpoint also had successful production requests, but new button clicks were not reaching the endpoint. The deployed HTML contained the button while browsers could continue using the older unversioned `chatbot.js`, which had no handler for it.

## What changed

- gives structured recommendation reviews a feature-specific 1,500-token output budget
- leaves the general chatbot output budget unchanged
- detects an explicitly incomplete OpenAI response before attempting to parse it
- versions chatbot JavaScript and CSS URLs to invalidate stale browser caches
- adds regression coverage for token overrides, incomplete responses, review configuration, and asset versioning

## User impact

AI-assisted reviews can now complete their strict JSON response instead of displaying the generic unavailable message. The “Compare alternatives with AI” button will load the current JavaScript handler and send its question to the chatbot.

The deterministic recommendation remains available if a genuine provider failure occurs.

## Validation

- production Vercel logs inspected to establish both root causes
- `python -m pytest -q tests/` — 132 passed
- focused integration and route tests — 47 passed
- `node --check public/static/js/chatbot.js` — passed
- fatal-error flake8 checks — passed
- `git diff --check` — passed
