### PR TITLE
Summarize AI chat responses within the output budget

### DIFF
--- a/routes/chatbot_routes.py
+++ b/routes/chatbot_routes.py
@@ -21,6 +21,7 @@ logger = logging.getLogger(__name__)
 chatbot_bp = Blueprint("chatbot", __name__, url_prefix="/chatbot")
 MAX_QUESTION_LENGTH = 1_000
 MAX_CONTEXT_LENGTH = 4_000
+CHATBOT_MAX_OUTPUT_TOKENS = 1_000
 
 
 @chatbot_bp.route("/ask", methods=["POST"])
@@ -88,13 +89,15 @@ def ask_question():
         "Do not claim that data, diagnostics, or assumptions were tested when "
         "they were not. For questions asking what could replace a recommended "
         "model, start with the verified compatible alternatives in the page "
-        "context. Give 3–6 concise bullets, each naming the alternative, when "
-        "it is preferable, and its main assumption or tradeoff. You may add "
+        "context. Summarize the answer in at most 120 words with no preamble. "
+        "Give at most 3 concise bullets, each naming the alternative, when it "
+        "is preferable, and its main assumption or tradeoff. You may add "
         "another model only when the stated design clearly supports it; label "
         "it as a conditional option rather than an engine-verified match. End "
-        "with the most important diagnostic or design fact needed to decide. "
-        "For other questions, answer concisely and state important assumptions "
-        "and uncertainty."
+        "with one short sentence naming the most important diagnostic or "
+        "design fact needed to decide. For other questions, answer in at most "
+        "120 words and state only the most important assumptions and "
+        "uncertainty."
     )
 
     try:
@@ -105,6 +108,7 @@ def ask_question():
             prompt,
             system_prompt=system_prompt,
             safety_identifier=safety_identifier,
+            max_output_tokens=CHATBOT_MAX_OUTPUT_TOKENS,
         )
     except OpenAIServiceError as exc:
         logger.warning(

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -370,8 +370,11 @@ def test_chatbot_guides_model_replacement_questions(
     assert "What other model can replace" in call.args[0]
     system_prompt = call.kwargs["system_prompt"]
     assert "verified compatible alternatives" in system_prompt
-    assert "3–6 concise bullets" in system_prompt
+    assert "at most 120 words" in system_prompt
+    assert "at most 3 concise bullets" in system_prompt
+    assert "with no preamble" in system_prompt
     assert "conditional option" in system_prompt
+    assert call.kwargs["max_output_tokens"] == 1_000
 
 
 def test_model_recommendation_can_use_ai_review(


### PR DESCRIPTION
## What changed

- Gives the chatbot a feature-specific 1,000-token response budget.
- Requires answers of at most 120 words with no preamble.
- Limits model-replacement comparisons to three concise alternatives and one decision sentence.
- Adds regression coverage for both the summary contract and output budget.

## Why

The shared 400-token limit includes GPT-5 mini reasoning tokens, so a concise visible answer could still end with an incomplete provider response. The new bounded chat budget leaves room for reasoning while the prompt keeps the user-facing answer short.

## Validation

- `pytest -q tests`: 132 passed
- Focused chatbot and output-budget tests: 3 passed