### PR TITLE
Compact the chatbot on mobile

### DIFF
--- a/public/static/css/chatbot.css
+++ b/public/static/css/chatbot.css
@@ -218,3 +218,67 @@
         bottom: 78px;
     }
 }
+
+@media (max-width: 576px) {
+    #chat-window {
+        right: 16px;
+        bottom: calc(128px + env(safe-area-inset-bottom, 0px));
+        width: min(330px, calc(100vw - 48px));
+        height: min(440px, 62dvh);
+        border-radius: 14px;
+    }
+
+    .chat-icon-container {
+        right: 16px;
+        bottom: calc(70px + env(safe-area-inset-bottom, 0px));
+    }
+
+    #chat-icon {
+        width: 46px;
+        height: 46px;
+    }
+
+    #chat-icon i {
+        font-size: 21px;
+    }
+
+    .chat-header {
+        padding: 11px 12px;
+    }
+
+    .chat-header h3 {
+        font-size: 15px;
+    }
+
+    #chat-messages {
+        padding: 10px;
+        gap: 8px;
+    }
+
+    .message {
+        margin-bottom: 6px;
+    }
+
+    .message-bubble {
+        max-width: 88%;
+        padding: 8px 10px;
+        font-size: 13px;
+    }
+
+    .chat-input {
+        padding: 10px;
+    }
+
+    #user-message {
+        min-width: 0;
+        padding: 8px 11px;
+        font-size: 13px;
+    }
+
+    #send-message {
+        width: 36px;
+        height: 36px;
+        margin-left: 8px;
+        flex: 0 0 36px;
+    }
+}

--- a/templates/base.html
+++ b/templates/base.html
@@ -10,7 +10,7 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.0/font/bootstrap-icons.css">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/app.css') }}">
-    <link rel="stylesheet" href="{{ url_for('static', filename='css/chatbot.css', v='20260725.1') }}">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/chatbot.css', v='20260725.2') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/page_search.css') }}">
     {% block extra_css %}{% endblock %}
 </head>
@@ -184,7 +184,7 @@
     </button>
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
-    <script src="{{ url_for('static', filename='js/chatbot.js', v='20260725.1') }}"></script>
+    <script src="{{ url_for('static', filename='js/chatbot.js', v='20260725.2') }}"></script>
     <script>
     document.addEventListener('DOMContentLoaded', function () {
         document.querySelectorAll('[data-bs-toggle="tooltip"]').forEach(function (element) {

--- a/templates/blank.html
+++ b/templates/blank.html
@@ -15,7 +15,7 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.0/font/bootstrap-icons.css">
     
     <!-- Chatbot CSS -->
-    <link rel="stylesheet" href="{{ url_for('static', filename='css/chatbot.css', v='20260725.1') }}">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/chatbot.css', v='20260725.2') }}">
     
     <!-- Page Search CSS -->
     <link rel="stylesheet" href="{{ url_for('static', filename='css/page_search.css') }}">
@@ -92,7 +92,7 @@
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
     
     <!-- Chatbot JS -->
-    <script src="{{ url_for('static', filename='js/chatbot.js', v='20260725.1') }}"></script>
+    <script src="{{ url_for('static', filename='js/chatbot.js', v='20260725.2') }}"></script>
     
     <!-- Page Search JS -->
     <script src="{{ url_for('static', filename='js/page_search.js') }}"></script>

--- a/tests/test_main_routes.py
+++ b/tests/test_main_routes.py
@@ -11,8 +11,8 @@ class TestMainRoutes:
         response = client.get('/')
         assert response.status_code == 200
         assert b'statistical' in response.data.lower() or b'model' in response.data.lower()
-        assert b'chatbot.js?v=20260725.1' in response.data
-        assert b'chatbot.css?v=20260725.1' in response.data
+        assert b'chatbot.js?v=20260725.2' in response.data
+        assert b'chatbot.css?v=20260725.2' in response.data
     def test_analysis_form_page(self, client):
         """Test that the analysis form page loads."""
         response = client.get('/analysis-form')


### PR DESCRIPTION
## What changed

- Caps the small-screen chatbot at 330px wide and 62dvh tall.
- Reduces header, message, input, and launcher sizing on phones.
- Respects mobile safe-area insets.
- Bumps chatbot asset versions to prevent stale CSS caching.

## Why

The existing mobile rule allowed the panel to occupy nearly the full viewport width and most of its height, making it feel oversized and obscuring the page.

## Validation

- `pytest -q tests/test_main_routes.py`: 25 passed
- `pytest -q tests`: 132 passed
- `git diff --check`: passed